### PR TITLE
[INJIMOB-2883] add sonar analysis to push trigger

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -1,0 +1,37 @@
+name: Push trigger for tuvali
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - qa-develop
+      - 'release-**'
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - master
+      - develop
+      - qa-develop
+      - 'release-**'
+
+jobs:
+  build-kotlin:
+    uses: mosip/kattu/.github/workflows/gradle-build.yml@master
+    with:
+      SERVICE_LOCATION: kotlin/android
+      JAVA_VERSION: 11
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
+
+  sonar_analysis:
+    needs: build-kotlin
+    if: "${{  github.event_name != 'pull_request' }}"
+    uses: mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@master-java21
+    with:
+      SERVICE_LOCATION: kotlin/android
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_ORGANIZATION: ${{ secrets.ORG_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
+

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -20,7 +20,7 @@ jobs:
     uses: mosip/kattu/.github/workflows/gradle-build.yml@master
     with:
       SERVICE_LOCATION: kotlin/android
-      JAVA_VERSION: 11
+      JAVA_VERSION: 17
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
 

--- a/kotlin/android/build.gradle
+++ b/kotlin/android/build.gradle
@@ -73,4 +73,13 @@ dependencies {
 
 }
 
+sonarqube {
+  properties {
+    property "sonar.java.binaries", "build/intermediates/javac/debug"
+    property "sonar.language", "kotlin"
+    property "sonar.exclusions", "**/build/**, **/*.kt.generated, **/R.java, **/BuildConfig.java"
+    property "sonar.scm.disabled", "true"
+  }
+}
+
 apply from: "publish-artifact.gradle"

--- a/kotlin/android/gradle.properties
+++ b/kotlin/android/gradle.properties
@@ -5,3 +5,4 @@ Tuvali_compileSdkVersion=31
 Tuvali_ndkversion=21.4.7075529
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=--add-opens=java.base/java.io=ALL-UNNAMED


### PR DESCRIPTION
**Notes**

- org.gradle.jvmargs=--add-opens=java.base/java.io=ALL-UNNAMED is added to resolve module accessibility issue while building with Java version 17 (sonar analysis job uses ubuntu-latest github runner image which has default Java version as 17)
```Execution failed for task ':processDebugAndroidTestManifest'.
> Unable to make field private final java.lang.String java.io.File.path accessible: module java.base does not "opens java.io" to unnamed module @3b0db9a9
```
- keeping Java version as 17 for building the project
- Tests are not written for the project so jacoco test report is not configured

**Local sonar analysis snapshot**
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/c997b5c6-5cfe-4d2f-8e7c-a8515c92079d" />
